### PR TITLE
Added messages to run & complete pings

### DIFF
--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -34,7 +34,7 @@ class Cronitor
   def create
     response = Unirest.post(
       "#{API_URL}/monitors",
-      headers: default_headers.merge('Content-Type': 'application/json'),
+      headers: default_headers.merge('Content-Type' => 'application/json'),
       auth: { user: token },
       parameters: opts.to_json
     )
@@ -105,6 +105,6 @@ class Cronitor
   end
 
   def default_headers
-    { 'Accept': 'application/json' }
+    { 'Accept' => 'application/json' }
   end
 end

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -34,7 +34,7 @@ class Cronitor
   def create
     response = Unirest.post(
       "#{API_URL}/monitors",
-      headers: default_headers.merge 'Content-Type' => 'application/json',
+      headers: default_headers.merge('Content-Type': 'application/json'),
       auth: { user: token },
       parameters: opts.to_json
     )
@@ -57,7 +57,7 @@ class Cronitor
 
   def ping(type, msg = nil)
     url = "#{PING_URL}/#{code}/#{type}"
-    url += "?msg=#{URI.escape msg}" if type == 'fail' && !msg.nil?
+    url += "?msg=#{URI.escape msg}" if ['run', 'complete', 'fail'].include?(type) && !msg.nil?
 
     response = Unirest.get url
     valid? response
@@ -105,6 +105,6 @@ class Cronitor
   end
 
   def default_headers
-    { 'Accept' => 'application/json' }
+    { 'Accept': 'application/json' }
   end
 end

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -57,7 +57,7 @@ class Cronitor
 
   def ping(type, msg = nil)
     url = "#{PING_URL}/#{code}/#{type}"
-    url += "?msg=#{URI.escape msg}" if ['run', 'complete', 'fail'].include?(type) && !msg.nil?
+    url += "?msg=#{URI.escape msg}" if %w(run complete fail).include?(type) && !msg.nil?
 
     response = Unirest.get url
     valid? response

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -172,6 +172,10 @@ RSpec.describe Cronitor do
           it 'notifies Cronitor' do
             expect(monitor.ping(ping_type)).to eq true
           end
+          it 'passes the message to Cronitor' do
+            monitor.ping(ping_type, 'your message here')
+            expect(FakeCronitor.requests.last.params).to include('msg' => 'your message here')
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ WebMock.disable_net_connect! allow_localhost: true
 
 RSpec.configure do |config|
   config.before(:each) do
-    stub_request(:any, /cronitor.(io|link)/).to_rack FakeCronitor
+    stub_request(:any, /cronitor.(io|link|ping)/).to_rack FakeCronitor
   end
 
   config.expect_with :rspec do |expectations|

--- a/spec/support/fake_cronitor.rb
+++ b/spec/support/fake_cronitor.rb
@@ -1,6 +1,10 @@
 require 'sinatra/base'
 
 class FakeCronitor < Sinatra::Base
+  class << self
+    attr_accessor :requests
+  end
+
   get '/v1/monitors/:id' do
     if ['efgh', 'Test Cronitor'].include? params['id']
       return json_response 200, 'existing_monitor'
@@ -12,16 +16,22 @@ class FakeCronitor < Sinatra::Base
   post '/v1/monitors' do
     payload = JSON.parse request.body.read
     # Check that we have the necessary payload values very simply
-    %w(name rules notifications).each do |k|
+    %w[name rules notifications].each do |k|
       return json_response 400, "invalid_no_#{k}" unless payload.key? k
     end
     json_response 200, 'new_monitor'
   end
 
-  %w(run complete fail).each do |ping|
+  %w[run complete fail].each do |ping|
     get "/abcd/#{ping}" do
-      200
+      content_type :json
+      status 200
+      params.to_json
     end
+  end
+
+  before do
+    self.class.requests = [self.class.requests, request]
   end
 
   private

--- a/spec/support/fake_cronitor.rb
+++ b/spec/support/fake_cronitor.rb
@@ -16,17 +16,15 @@ class FakeCronitor < Sinatra::Base
   post '/v1/monitors' do
     payload = JSON.parse request.body.read
     # Check that we have the necessary payload values very simply
-    %w[name rules notifications].each do |k|
+    %w(name rules notifications).each do |k|
       return json_response 400, "invalid_no_#{k}" unless payload.key? k
     end
     json_response 200, 'new_monitor'
   end
 
-  %w[run complete fail].each do |ping|
+  %w(run complete fail).each do |ping|
     get "/abcd/#{ping}" do
-      content_type :json
-      status 200
-      params.to_json
+      200
     end
   end
 

--- a/spec/support/fake_cronitor.rb
+++ b/spec/support/fake_cronitor.rb
@@ -29,6 +29,9 @@ class FakeCronitor < Sinatra::Base
   end
 
   before do
+    # Storing requests here in a class instance variable so that the rspec
+    # tests can examine the request stack, specifically that the requests
+    # to the cronitor API contain the correct paramaters.
     self.class.requests = [self.class.requests, request]
   end
 


### PR DESCRIPTION
The run & complete pings can also take message arguments; this commit
adds tests around that, and then implements the change.

Additional minor styling changes for hashes for compatability.