### PR TITLE
Replace Unirest with just Net::HTTP

### DIFF
--- a/cronitor.gemspec
+++ b/cronitor.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'unirest', '~> 1.1'
   spec.add_dependency 'hashie', '~> 3.4'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/lib/cronitor.rb
+++ b/lib/cronitor.rb
@@ -1,8 +1,10 @@
 require 'cronitor/version'
 require 'cronitor/error'
-require 'net/http'
-require 'unirest'
+
 require 'hashie'
+require 'json'
+require 'net/http'
+require 'uri'
 
 class Cronitor
   attr_accessor :token, :opts, :code
@@ -32,34 +34,52 @@ class Cronitor
   end
 
   def create
-    response = Unirest.post(
-      "#{API_URL}/monitors",
-      headers: default_headers.merge('Content-Type' => 'application/json'),
-      auth: { user: token },
-      parameters: opts.to_json
-    )
+    uri = URI.parse("#{API_URL}/monitors")
 
-    @code = response.body['code'] if valid? response
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    request = Net::HTTP::Post.new(uri.path, default_headers)
+    request.basic_auth token, nil
+    request.content_type = 'application/json'
+    request.body = JSON.generate(opts)
+
+    response = http.request(request)
+
+    @code = JSON.parse(response.body).fetch('code') if valid? response
   end
 
   def exists?(name)
-    response = Unirest.get(
-      "#{API_URL}/monitors/#{URI.escape(name).gsub('[', '%5B').gsub(']', '%5D')}",
-      headers: default_headers,
-      auth: { user: token }
-    )
-    return false unless response.code == 200
+    uri = URI.parse("#{API_URL}/monitors/#{URI.escape(name)}")
 
-    @code = response.body['code']
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    request = Net::HTTP::Get.new(uri.path, default_headers)
+    request.basic_auth token, nil
+
+    response = http.request(request)
+
+    return false unless response.is_a? Net::HTTPSuccess
+
+    @code = JSON.parse(response.body).fetch('code')
 
     true
   end
 
   def ping(type, msg = nil)
-    url = "#{PING_URL}/#{code}/#{type}"
-    url += "?msg=#{URI.escape msg}" if %w(run complete fail).include?(type) && !msg.nil?
+    uri = URI.parse("#{PING_URL}/#{URI.escape(code)}/#{URI.escape(type)}")
+    if %w(run complete fail).include?(type) && !msg.nil?
+      uri.query = URI.encode_www_form("msg" => msg)
+    end
 
-    response = Unirest.get url
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
+
+    request = Net::HTTP::Get.new(uri, default_headers)
+
+    response = http.request(request)
+
     valid? response
   end
 
@@ -75,10 +95,13 @@ class Cronitor
   private
 
   def valid?(response)
-    return true if [200, 201].include? response.code
-    server_error? response
+    return true if response.is_a? Net::HTTPSuccess
 
-    raise Cronitor::Error, error_msg(response.body)
+    if response.content_type =~ /json/
+      raise Cronitor::Error, error_msg(JSON.parse(response.body))
+    else
+      raise Cronitor::Error, "Something else has gone awry. HTTP status: #{response.code}"
+    end
   end
 
   def error_msg(body, msg = [])
@@ -93,15 +116,6 @@ class Cronitor
     end
 
     msg.join ' '
-  end
-
-  def server_error?(response)
-    return unless [301, 302, 404, 500, 502, 503, 504].include? response.code
-
-    raise(
-      Cronitor::Error,
-      "Something else has gone awry. HTTP status: #{response.code}"
-    )
   end
 
   def default_headers

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Cronitor do
           end
           it 'passes the message to Cronitor' do
             monitor.ping(ping_type, 'your message here')
-            expect(FakeCronitor.requests.last.params).to include('msg' => 'your message here')
+            expect(FakeCronitor.last_request.params).to include('msg' => 'your message here')
           end
         end
       end

--- a/spec/support/fake_cronitor.rb
+++ b/spec/support/fake_cronitor.rb
@@ -2,7 +2,7 @@ require 'sinatra/base'
 
 class FakeCronitor < Sinatra::Base
   class << self
-    attr_accessor :requests
+    attr_accessor :last_request
   end
 
   get '/v1/monitors/:id' do
@@ -29,10 +29,8 @@ class FakeCronitor < Sinatra::Base
   end
 
   before do
-    # Storing requests here in a class instance variable so that the rspec
-    # tests can examine the request stack, specifically that the requests
-    # to the cronitor API contain the correct paramaters.
-    self.class.requests = [self.class.requests, request]
+    # Store last request here so rspec an inspect request, specifically for ping msg param
+    self.class.last_request = request
   end
 
   private


### PR DESCRIPTION
We're having a dependency issue where unirest requires an old version of json which doesn't work on contemporary ruby, so I thought it'd be neat to get closer to zero-deps by replacing usage of unirest with straight Net::HTTP. It's not super different, although Net::HTTP is still cumbersome as heck.

See what you think?