### PR TITLE
Update webmock to work on ruby 2.4+

### DIFF
--- a/cronitor.gemspec
+++ b/cronitor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'webmock', '~> 1.21'
+  spec.add_development_dependency 'webmock', '~> 2.3', '>= 2.3.1'
   spec.add_development_dependency 'sinatra', '~> 1.4'
   spec.add_development_dependency 'bump', '~> 0.1'
 end


### PR DESCRIPTION
I got lots of this while trying to dev on my machine:

```
  1) Cronitor sets its config correctly has the specified options
     Failure/Error:
       response = Unirest.get(
         "#{API_URL}/monitors/#{URI.escape(name).gsub('[', '%5B').gsub(']', '%5D')}",
         headers: default_headers,
         auth: { user: token }
       )

     NoMethodError:
       undefined method `close' for #<StubSocket:0x007f8de75d28a8>
     # ./lib/cronitor.rb:46:in `exists?'
     # ./lib/cronitor.rb:27:in `initialize'
     # ./spec/cronitor_spec.rb:17:in `new'
     # ./spec/cronitor_spec.rb:17:in `block (3 levels) in <top (required)>'
     # ./spec/cronitor_spec.rb:25:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # RestClient::ResourceNotFound:
     #   404 Resource Not Found
     #   ./lib/cronitor.rb:46:in `exists?'
```

Seems to be this issue which is fixed in webmock >= 2.3.1:

https://github.com/bblimke/webmock/issues/683

Simply updating seems to work fine.