### PR TITLE
Update to work with Cronitor API v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ Or install it yourself as:
 
 A Cronitor monitor (hereafter referred to only as a monitor for brevity) is created if it does not already exist, and its ID returned.
 
+Please see the [Cronitor Monitor API docs](https://cronitor.io/docs/monitor-api) for details of all the possible monitor options.
+
+Example of creating a heartbeat monitor:
+
 ```ruby
 require 'cronitor'
 
 monitor_options = {
   name: 'My Fancy Monitor',
+  type: 'heartbeat', # Optional: the gem defaults to this; the other value, 'healthcheck', is not yet supported by this gem
   notifications: {
     emails: ['test@example.com'],
     slack: [],
@@ -43,8 +48,8 @@ monitor_options = {
   },
   rules: [
     {
-      rule_type: 'not_run_in',
-      duration: 5,
+      rule_type: 'run_ping_not_received',
+      value: 5,
       time_unit: 'seconds'
     }
   ],
@@ -53,20 +58,6 @@ monitor_options = {
 
 # The token parameter is optional; if omittted, ENV['CRONITOR_TOKEN'] will be used
 my_monitor = Cronitor.new token: 'api_token', opts: monitor_options
-```
-
-You may optionally specify a `:human_readable` value for your rule(s), otherwise one will be crafted for you:
-
-```ruby
-monitor_options = {
-  rules: [
-    {
-      rule_type: 'not_run_in',
-      duration: 5
-      time_unit: 'seconds',
-      human_readable: 'not_run_in 5 seconds'
-    }
-  ],
 ```
 
 ### Updating an existing monitor

--- a/spec/cronitor_spec.rb
+++ b/spec/cronitor_spec.rb
@@ -58,26 +58,6 @@ RSpec.describe Cronitor do
         end
       end
 
-      context 'when a human readable rule is not provided' do
-        it 'sets a human readable rule' do
-          expect(monitor.opts[:rules].first[:human_readable]).to(
-            eq 'not_completed_in 5 seconds'
-          )
-        end
-      end
-
-      context 'when a human readable rule is provided' do
-        before do
-          monitor_options[:rules].first[:human_readable] = 'A human rule'
-        end
-
-        it 'sets a human readable rule' do
-          expect(monitor.opts[:rules].first[:human_readable]).to(
-            eq 'A human rule'
-          )
-        end
-      end
-
       context 'when the monitor does not exist' do
         it 'creates a monitor' do
           expect(monitor.code).to eq 'abcd'

--- a/spec/support/fake_cronitor.rb
+++ b/spec/support/fake_cronitor.rb
@@ -7,7 +7,7 @@ class FakeCronitor < Sinatra::Base
     attr_accessor :last_request
   end
 
-  get '/v1/monitors/:id' do
+  get '/v3/monitors/:id' do
     if ['efgh', 'Test Cronitor'].include? params['id']
       return json_response 200, 'existing_monitor'
     end
@@ -15,7 +15,7 @@ class FakeCronitor < Sinatra::Base
     json_response 404
   end
 
-  post '/v1/monitors' do
+  post '/v3/monitors' do
     payload = JSON.parse request.body.read
     # Check that we have the necessary payload values very simply
     %w[name rules notifications].each do |k|

--- a/spec/support/fixtures/existing_monitor.json
+++ b/spec/support/fixtures/existing_monitor.json
@@ -1,5 +1,6 @@
 {
   "code": "efgh",
+  "type": "heartbeat",
   "initialized": true,
   "disabled": false,
   "is_paused": false,
@@ -15,14 +16,14 @@
     ],
     "slack": []
   },
-  "rules": {
-    "6141": {
-      "rule_type": "not_completed_in",
+  "rules": [
+    {
+      "rule_type": "complete_ping_not_received",
       "duration": 5,
       "human_readable": "Has not received a complete ping in over 5 minutes",
       "time_unit": "minutes",
       "hours_to_followup_alert": 4
     }
-  },
+  ],
   "note": null
 }

--- a/spec/support/fixtures/new_monitor.json
+++ b/spec/support/fixtures/new_monitor.json
@@ -1,5 +1,6 @@
 {
   "code": "abcd",
+  "type": "heartbeat",
   "initialized": true,
   "disabled": false,
   "is_paused": false,
@@ -15,14 +16,14 @@
     ],
     "slack": []
   },
-  "rules": {
-    "6141": {
-      "rule_type": "not_completed_in",
+  "rules": [
+    {
+      "rule_type": "complete_ping_not_received",
       "duration": 5,
       "human_readable": "Has not received a complete ping in over 5 minutes",
       "time_unit": "minutes",
       "hours_to_followup_alert": 4
     }
-  },
+  ],
   "note": "A human-friendly description of this monitor"
 }


### PR DESCRIPTION
Thanks to excellent docs on the breaking changes from v1 to v2 & v3, we now support the most recent version of the Cronitor monitor API.

Closes #13